### PR TITLE
feat: tag removing support

### DIFF
--- a/LabelWorkshop/Localizable.xcstrings
+++ b/LabelWorkshop/Localizable.xcstrings
@@ -858,6 +858,17 @@
     "LabelWorkshop" : {
       "shouldTranslate" : false
     },
+    "remove" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove"
+          }
+        }
+      }
+    },
     "save" : {
       "localizations" : {
         "en" : {

--- a/LabelWorkshop/views/EntryView.swift
+++ b/LabelWorkshop/views/EntryView.swift
@@ -34,6 +34,7 @@ struct EntryView: View {
                                 } label: {
                                     TagView(tag: tag)
                                 }
+                                .buttonStyle(.plain)
                             }
                             .sheet(isPresented: $showTagSelector) {
                                 NavigationView {

--- a/LabelWorkshop/views/EntryView.swift
+++ b/LabelWorkshop/views/EntryView.swift
@@ -24,7 +24,16 @@ struct EntryView: View {
                         Text("entry.tags").font(.title2).frame(maxWidth: .infinity, alignment: .leading)
                         HFlow {
                             ForEach($tags){ $tag in
-                                TagView(tag: tag)
+                                Menu {
+                                    Button(role: .destructive, action: {
+                                        self.entry.removeTag(tag)
+                                        self.tags = entry.getTags()
+                                    }) {
+                                        Label("remove", systemImage: "minus")
+                                    }
+                                } label: {
+                                    TagView(tag: tag)
+                                }
                             }
                             .sheet(isPresented: $showTagSelector) {
                                 NavigationView {


### PR DESCRIPTION
# Details
Adds a menu that shows up when clicking a tag in an entry. Within the menu a remove button will show up. Clicking remove will remove the tag from the current entry.

Closes

## Testing
- [x] iPhone Simulator
    - [x] 18.5
- [ ] iPhone Physical
- [ ] iPad Simulator
- [ ] iPad Physical
